### PR TITLE
SELV3-553: Enable Edit server option (Frontend)

### DIFF
--- a/src/admin-dhis2/admin-dhis2.service.js
+++ b/src/admin-dhis2/admin-dhis2.service.js
@@ -37,6 +37,10 @@
                 url: openlmisUrlFactory('/api/serverConfiguration/'),
                 method: 'POST'
             },
+            editServer: {
+                url: openlmisUrlFactory('/api/serverConfiguration/:id'),
+                method: 'PUT'
+            },
             removeServer: {
                 url: openlmisUrlFactory('/api/serverConfiguration/:id'),
                 method: 'DELETE'
@@ -45,6 +49,7 @@
 
         this.getServerConfig = getServerConfig;
         this.addServer = addServer;
+        this.editServer = editServer;
         this.removeServer = removeServer;
 
         function getServerConfig() {
@@ -54,6 +59,12 @@
         function addServer(server) {
             var requestServerData = server.items[0];
             return resource.addServer(requestServerData).$promise;
+        }
+
+        function editServer(server, serverId) {
+            return resource.editServer({
+                id: serverId
+            }, server).$promise;
         }
 
         function removeServer(server) {

--- a/src/admin-dhis2/components/AdminDhis2ServersForm/AdminDhis2ServersForm.jsx
+++ b/src/admin-dhis2/components/AdminDhis2ServersForm/AdminDhis2ServersForm.jsx
@@ -8,7 +8,7 @@ import { toast } from 'react-toastify';
 import getService from '../../../react-components/utils/angular-utils';
 import InputField from '../../../react-components/form-fields/input-field';
 import AddButton from '../../../react-components/buttons/add-button';
-
+import ResponsiveButton from '../../../react-components/buttons/responsive-button';
 
 function AdminDhis2ServersForm({
     onSubmit, onCancel, 
@@ -50,13 +50,28 @@ function AdminDhis2ServersForm({
   const addServer = (server) => {
       serverService.addServer(server).then(() => {
           onCancel();
-          toast.success("Server saved successfully!");
+          toast.success("Server added successfully!");
           refetch();
       })
       .catch((error) => {
           onCancel();
           toast.error(error);
       })
+  }
+
+  const editServer = (server) => {
+    const requestServerData = server.items[0];
+    const serverId = requestServerData.id;
+    delete requestServerData.id;
+    serverService.editServer(requestServerData, serverId).then(() => {
+        onCancel();
+        toast.success("Server saved successfully!");
+        refetch();
+    })
+    .catch((error) => {
+        onCancel();
+        toast.error(error);
+    })
   }
 
   return (
@@ -83,6 +98,7 @@ function AdminDhis2ServersForm({
                                         <div key={name}>
                                             <InputField
                                                 required
+                                                maxLength={50}
                                                 numeric={false}
                                                 name={`${name}.name`}
                                                 label="Name"
@@ -90,6 +106,7 @@ function AdminDhis2ServersForm({
                                             />
                                             <InputField
                                                 required
+                                                maxLength={100}
                                                 numeric={false}
                                                 name={`${name}.url`}
                                                 label="Url"
@@ -97,6 +114,7 @@ function AdminDhis2ServersForm({
                                             />
                                             <InputField
                                                 required
+                                                maxLength={50}
                                                 numeric={false}
                                                 name={`${name}.username`}
                                                 label="Username"
@@ -104,6 +122,7 @@ function AdminDhis2ServersForm({
                                             />
                                             <InputField
                                                 required
+                                                maxLength={50}
                                                 numeric={false}
                                                 type='password'
                                                 name={`${name}.password`}
@@ -117,22 +136,33 @@ function AdminDhis2ServersForm({
                                 <div className="navbar">
                                     <div id='navbar-wrap'>
                                         <div>
-                                            <button type="button" className="primary">
-                                                <span>Test</span>
+                                            <button 
+                                                type="button" 
+                                                className="secondary" 
+                                                onClick={onCancel}
+                                            >
+                                                <span>Cancel</span>
                                             </button>
                                         </div>
                                         
                                         <div>
-                                            <AddButton
-                                                className="primary"
-                                                disabled={invalid}
-                                                onClick={() => addServer(values)}
-                                            >
-                                                Add
-                                            </AddButton>
-                                            <button type="button" className="danger" onClick={onCancel}>
-                                                <span>Cancel</span>
-                                            </button>
+                                            { mode === 'Add' ?
+                                                <AddButton
+                                                    className="primary"
+                                                    disabled={invalid}
+                                                    onClick={() => addServer(values)}
+                                                >
+                                                    Add
+                                                </AddButton>
+                                            :
+                                                <ResponsiveButton
+                                                    className="primary" 
+                                                    disabled={invalid}
+                                                    onClick={() => editServer(values)}
+                                                >
+                                                    Edit
+                                                </ResponsiveButton>
+                                            }
                                         </div>
                                     </div>
                                 </div>

--- a/src/admin-dhis2/components/AdminDhis2ServersPage/AdminDhis2ServersPage.jsx
+++ b/src/admin-dhis2/components/AdminDhis2ServersPage/AdminDhis2ServersPage.jsx
@@ -31,6 +31,8 @@ const AdminDhis2ServersPage = () => {
     
     const [serversParams, setServersParams] = useState([]);
     const [displayAddModal, setDisplayAddModal] = useState(false);
+    const [displayEditModal, setDisplayEditModal] = useState(false);
+    const [objectToEdit, setObjectToEdit] = useState({ id: null });
 
     const serverService = useMemo(
         () => {
@@ -43,12 +45,14 @@ const AdminDhis2ServersPage = () => {
         serverService.getServerConfig()
             .then((fetchedServer) => {
                 const { content } = fetchedServer
-
+                
                 const serversParams = content.map((server) => ({
                     serverId: server.id,
                     serverName: server.name,
                     serverUrl: server.url,
-                    serverUsername: server.username
+                    serverUsername: server.username,
+                    // TODO - password - make double verification of password
+                    serverPassword: server.password
                 }))
                 setServersParams(serversParams);
             });
@@ -62,6 +66,27 @@ const AdminDhis2ServersPage = () => {
 
     const onSubmitAdd = () => {
         toggleAddModal();
+    };
+
+    const toggleEditModal = (record) => {
+        if (record && record.serverId !== undefined) {
+            const serverObject = serversParams.find(
+                (server) => server.serverId === record.serverId
+            );
+            setObjectToEdit((prevState) => ({
+                ...prevState,
+                id: serverObject.serverId,
+                name: serverObject.serverName,
+                username: serverObject.serverUsername,
+                url: serverObject.serverUrl,
+                password: serverObject.serverPassword,
+            }));
+        }
+        setDisplayEditModal(!displayEditModal);
+    };
+
+    const onSubmitEdit = (record) => {
+        toggleEditModal(record);
     };
 
     const removeServer = (server) => {
@@ -108,7 +133,9 @@ const AdminDhis2ServersPage = () => {
                         >
                             View
                         </ResponsiveButton>
-                        <ResponsiveButton>
+                        <ResponsiveButton
+                            onClick={() => toggleEditModal(values)}
+                        >
                             Edit
                         </ResponsiveButton>
                         <TrashButton
@@ -144,13 +171,13 @@ const AdminDhis2ServersPage = () => {
                 </div>
             </div>
             <Modal
-                isOpen={displayAddModal}
+                isOpen={displayAddModal || displayEditModal}
                 children={[
                     <AdminDhis2ServersForm
-                        onSubmit={onSubmitAdd}
-                        onCancel={toggleAddModal} 
+                        onSubmit={displayAddModal ? onSubmitAdd : onSubmitEdit}
+                        onCancel={displayAddModal ? toggleAddModal : toggleEditModal} 
                         title={displayAddModal ? 'Add Server' : 'Edit Server'}
-                        initialFormValue={[{}]} 
+                        initialFormValue={displayAddModal ? [{}] : [objectToEdit]} 
                         mode={displayAddModal ? 'Add' : 'Edit'}
                         refetch={fetchServersList}
                     />


### PR DESCRIPTION
TICKET: https://openlmis.atlassian.net/browse/SELV3-555

Added Edit Server Modal based on the ServerForm

Including requested changes:
 - set limits of characters in add/edit modals
 - remove 'test' button, moved 'cancel' button to the left (changed background color to the grey),moved  'add' one to the right side of modal. 

Presentation of change: 
![Peek 2023-01-25 15-01](https://user-images.githubusercontent.com/52816247/214588108-5f35ed86-e52c-4bf2-97c4-a51169694a33.gif)

NOTE: 
I talked with Nikola @NikolaLaskowska  about one particular change regarding password processing. For that moment is not a good practice to have password returned in GET endpoint as 'plain text'. For me it could be good to have in Add/Edit form two fields for password (one of them will be for password confirmation) therefore backend must verify those pair of passwords. That is  my proposal. 