### PR TITLE
SELV3-640: Changed data element endpoint

### DIFF
--- a/src/admin-dhis2/admin-dhis2.service.js
+++ b/src/admin-dhis2/admin-dhis2.service.js
@@ -77,6 +77,10 @@
                 url: openlmisUrlFactory('/api/serverConfiguration/:serverId/datasets/:datasetId/dhisElements'),
                 method: 'GET'
             },
+            getDhisElementCombos: {
+                url: openlmisUrlFactory('/api/serverConfiguration/:serverId/datasets/:datasetId/elementsAndCombos'),
+                method: 'GET'
+            },
             syncServers: {
                 url: openlmisUrlFactory('/api/execute'),
                 method: 'POST'
@@ -102,6 +106,7 @@
         this.addDataElement = addDataElement;
 
         this.getDhisElements = getDhisElements;
+        this.getDhisElementCombos = getDhisElementCombos;
         this.getDataOrderables = getDataOrderables;
         this.syncServers = syncServers;
 
@@ -177,6 +182,13 @@
 
         function getDhisElements(serverId, datasetId) {
             return resource.getDhisElements({
+                serverId: serverId,
+                datasetId: datasetId
+            }, datasetId).$promise;
+        }
+
+        function getDhisElementCombos(serverId, datasetId) {
+            return resource.getDhisElementCombos({
                 serverId: serverId,
                 datasetId: datasetId
             }, datasetId).$promise;

--- a/src/admin-dhis2/components/AdminDhis2DataElementForm/AdminDhis2DataElementForm.jsx
+++ b/src/admin-dhis2/components/AdminDhis2DataElementForm/AdminDhis2DataElementForm.jsx
@@ -60,7 +60,7 @@ function AdminDhis2DataElementForm({ onSubmit, onCancel, refetch, serverId, data
 
     const fetchDataElements = () => {
         if (datasetId) {
-            serverService.getDhisElements(serverId, datasetId)
+            serverService.getDhisElementCombos(serverId, datasetId)
                 .then((fetchedDhisElements) => {
                     const {content} = fetchedDhisElements;
 


### PR DESCRIPTION
Replace existing data element endpoint with combination of data elements and category option combos.
I left old data element endpoint with the idea that in near future, we will probably need to separate category option combos from data elements, as too many combinations may be produced.