### PR TITLE
SELV3-702: Disabled SMS notification channel

### DIFF
--- a/src/openlmis-user/notification-channel.constant.js
+++ b/src/openlmis-user/notification-channel.constant.js
@@ -1,0 +1,82 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+     * @ngdoc object
+     * @name openlmis-user.NOTIFICATION_CHANNEL
+     *
+     * @description
+     * Stores the list of all available notification channels and a method to get their labels.
+     */
+    angular
+        .module('openlmis-user')
+        .constant('NOTIFICATION_CHANNEL', NOTIFICATION_CHANNEL());
+
+    function NOTIFICATION_CHANNEL() {
+        var NOTIFICATION_CHANNEL = {
+                EMAIL: 'EMAIL',
+                getLabel: getLabel,
+                getChannels: getChannels
+            },
+            labels = {
+                EMAIL: 'openlmisUser.email'
+            };
+
+        return NOTIFICATION_CHANNEL;
+
+        /**
+         * @ngdoc method
+         * @methodOf openlmis-user.NOTIFICATION_CHANNEL
+         * @name getLabel
+         *
+         * @description
+         * Returns a label for the given channel. Throws an exception if the channel is not recognized.
+         *
+         * @param   {String}    channel  the notification channel
+         * @return  {String}             the label
+         */
+        function getLabel(channel) {
+            var label = labels[channel];
+
+            if (!label) {
+                throw '"' + channel + '" is not a valid channel';
+            }
+
+            return label;
+        }
+
+        /**
+         * @ngdoc method
+         * @methodOf openlmis-user.NOTIFICATION_CHANNEL
+         * @name getChannels
+         *
+         * @description
+         * Returns all available channels as a list.
+         *
+         * @return  {Array} the list of available channels
+         */
+        function getChannels() {
+            return [
+                NOTIFICATION_CHANNEL.EMAIL
+            ];
+        }
+
+    }
+
+})();

--- a/src/openlmis-user/notification-channel.constant.spec.js
+++ b/src/openlmis-user/notification-channel.constant.spec.js
@@ -1,0 +1,72 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+describe('NOTIFICATION_CHANNEL', function() {
+
+    beforeEach(function() {
+        module('openlmis-user');
+
+        inject(function($injector) {
+            this.NOTIFICATION_CHANNEL = $injector.get('NOTIFICATION_CHANNEL');
+        });
+    });
+
+    describe('getLabel', function() {
+
+        it('should return label for valid channel', function() {
+            expect(
+                this.NOTIFICATION_CHANNEL.getLabel('EMAIL')
+            ).toEqual('openlmisUser.email');
+        });
+
+        it('should throw exception for invalid channel', function() {
+            var NOTIFICATION_CHANNEL = this.NOTIFICATION_CHANNEL;
+
+            expect(function() {
+                NOTIFICATION_CHANNEL.getLabel('NON_EXISTENT_CHANNEL');
+            }).toThrow('"NON_EXISTENT_CHANNEL" is not a valid channel');
+
+            expect(function() {
+                NOTIFICATION_CHANNEL.getLabel(undefined);
+            }).toThrow('"undefined" is not a valid channel');
+
+            expect(function() {
+                NOTIFICATION_CHANNEL.getLabel(null);
+            }).toThrow('"null" is not a valid channel');
+
+            expect(function() {
+                NOTIFICATION_CHANNEL.getLabel('');
+            }).toThrow('"" is not a valid channel');
+
+            // SELV3-702: for now, SMS channel is not supported
+            expect(function() {
+                NOTIFICATION_CHANNEL.getLabel('SMS');
+            }).toThrow('"SMS" is not a valid channel');
+            // --- ends here ---
+        });
+
+    });
+
+    describe('getStatuses', function() {
+
+        it('should return a list of channels', function() {
+            expect(this.NOTIFICATION_CHANNEL.getChannels()).toEqual([
+                'EMAIL'
+            ]);
+        });
+
+    });
+
+});

--- a/src/openlmis-user/user-profile-notification-settings.controller.spec.js
+++ b/src/openlmis-user/user-profile-notification-settings.controller.spec.js
@@ -1,0 +1,160 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+describe('UserProfileNotificationSettingsController', function() {
+
+    beforeEach(function() {
+        module('openlmis-user');
+
+        inject(function($injector) {
+            this.$controller = $injector.get('$controller');
+            this.DigestConfigurationDataBuilder = $injector.get('DigestConfigurationDataBuilder');
+            this.UserSubscriptionDataBuilder = $injector.get('UserSubscriptionDataBuilder');
+            this.ObjectReferenceDataBuilder = $injector.get('ObjectReferenceDataBuilder');
+            this.UserDataBuilder = $injector.get('UserDataBuilder');
+            this.UserSubscriptionResource = $injector.get('UserSubscriptionResource');
+            this.$q = $injector.get('$q');
+            this.$rootScope = $injector.get('$rootScope');
+            this.$state = $injector.get('$state');
+            this.NOTIFICATION_CHANNEL = $injector.get('NOTIFICATION_CHANNEL');
+        });
+
+        this.digestConfigurations = [
+            new this.DigestConfigurationDataBuilder().buildJson(),
+            new this.DigestConfigurationDataBuilder().buildJson(),
+            new this.DigestConfigurationDataBuilder().buildJson()
+        ];
+
+        this.userSubscriptions = [
+            new this.UserSubscriptionDataBuilder()
+                .withCronExpression('0 0 * * *')
+                .withDigestConfiguration(
+                    new this.ObjectReferenceDataBuilder()
+                        .withId(this.digestConfigurations[0].id)
+                        .build()
+                )
+                .buildJson(),
+            new this.UserSubscriptionDataBuilder()
+                .withCronExpression('0 0 * * *')
+                .withDigestConfiguration(
+                    new this.ObjectReferenceDataBuilder()
+                        .withId(this.digestConfigurations[2].id)
+                        .build()
+                )
+                .buildJson()
+        ];
+
+        this.user = new this.UserDataBuilder().build();
+
+        spyOn(this.$state, 'reload');
+        spyOn(this.UserSubscriptionResource.prototype, 'create').andReturn(this.$q.resolve([
+            this.userSubscriptions[1]
+        ]));
+
+        this.vm = this.$controller('UserProfileNotificationSettingsController', {
+            digestConfigurations: this.digestConfigurations,
+            userSubscriptions: this.userSubscriptions,
+            user: this.user
+        });
+        this.vm.$onInit();
+    });
+
+    describe('$onInit', function() {
+
+        it('should set the list of digest configurations', function() {
+            expect(this.vm.digestConfigurations).toEqual(this.digestConfigurations);
+        });
+
+        it('should map user subscriptions by digest configuration ID', function() {
+            var expected = {};
+            expected[this.digestConfigurations[0].id] = this.userSubscriptions[0];
+            expected[this.digestConfigurations[1].id] = {
+                useDigest: false,
+                cronExpression: undefined,
+                preferredChannel: this.NOTIFICATION_CHANNEL.EMAIL,
+                digestConfiguration: this.digestConfigurations[1]
+            };
+            expected[this.digestConfigurations[2].id] = this.userSubscriptions[1];
+
+            expect(this.vm.userSubscriptionsMap).toEqual(expected);
+        });
+
+    });
+
+    describe('saveUserSubscriptions', function() {
+
+        it('should update user subscriptions', function() {
+            this.vm.saveUserSubscriptions();
+            this.$rootScope.$apply();
+
+            expect(this.UserSubscriptionResource.prototype.create).toHaveBeenCalledWith([
+                this.vm.userSubscriptionsMap[this.digestConfigurations[0].id],
+                this.vm.userSubscriptionsMap[this.digestConfigurations[1].id],
+                this.vm.userSubscriptionsMap[this.digestConfigurations[2].id]
+            ], {
+                userId: this.user.id
+            });
+        });
+
+        it('should return promise', function() {
+            var success;
+            this.vm.saveUserSubscriptions()
+                .then(function() {
+                    success = true;
+                });
+
+            this.$rootScope.$apply();
+
+            expect(success).toEqual(true);
+        });
+
+        it('should reload state on success', function() {
+            this.vm.saveUserSubscriptions();
+            this.$rootScope.$apply();
+
+            expect(this.$state.reload).toHaveBeenCalled();
+        });
+
+        it('should not reload on error', function() {
+            this.UserSubscriptionResource.prototype.create.andReturn(this.$q.reject());
+
+            this.vm.saveUserSubscriptions();
+            this.$rootScope.$apply();
+
+            expect(this.$state.reload).not.toHaveBeenCalled();
+        });
+
+    });
+
+    describe('validateSubscription', function() {
+
+        it('should not return error if email channel is selected for digest message', function() {
+            var userSubscription = this.vm.userSubscriptionsMap[this.digestConfigurations[0].id];
+            userSubscription.preferredChannel = this.NOTIFICATION_CHANNEL.EMAIL;
+
+            expect(this.vm.validateSubscription(userSubscription)).toBeUndefined();
+        });
+
+        it('should not return error if channel is not specified', function() {
+            var userSubscription = this.vm.userSubscriptionsMap[this.digestConfigurations[0].id];
+            userSubscription.preferredChannel = undefined;
+            userSubscription.useDigest = false;
+
+            expect(this.vm.validateSubscription(userSubscription)).toBeUndefined();
+        });
+
+    });
+
+});


### PR DESCRIPTION
This code removes 'SMS' option from Notification Settings screen, as this implementation does not use this form of contact. 
Identical fix was implemented previously here: https://github.com/OpenLMIS-Malawi/mw-ui/commit/e01556d73e47b41ee5eeaceaead652f6f895fca1
![image](https://github.com/villagereach/selv-v3-ui/assets/113436691/e8fbf6af-c785-4530-aad0-3f889cd5755e)
