### PR TITLE
SELV3-780: add health area geo lvl, enable feature flag by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ Before pushing a new version of the docker image, you need to provide user-based
 AUTH_SERVER_CLIENT_ID=<clientId>
 AUTH_SERVER_CLIENT_SECRET=<clientSecret>
 ```
+
+## Feature Flags
+- `CATCHMENT_POPULATION_CALC_AUTO`: By default __true__. This feature flag controls whether the catchment population is automatically aggregated (`editable only in the lowest-level geo zones, such as districts, and then automatically propagated to higher levels like provinces and the country`) or allows for manual editing. You can modify the default value in the file: `catchment-population-auto-calc.flag.run.js`. Additionally, you can define which geographic level should be treated as the lowest (e.g., if a level lower than the district is introduced) in: `geographic-level.service.js`. You can also modify `CATCHMENT_POPULATION_CALC_AUTO` via `settings.env`.

--- a/src/admin-data-import/consts.jsx
+++ b/src/admin-data-import/consts.jsx
@@ -1,0 +1,32 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+export const TYPE_OF_IMPORTS = [
+    {
+        value: "Product",
+        name: "Products",
+        info: "To import Products you need: orderable.csv, programOrderable.csv, tradeItem.csv"
+    },
+    {
+        value: "Facility",
+        name: "Facilities",
+        info: "To import Facilities you need: facility.csv, supportedProgram.csv"
+    },
+    {
+        value: "GeographicZone",
+        name: "Geographic Zones",
+        info: "To import Geographic Zones you need a ZIP with a geographicZone.csv file."
+    }
+];

--- a/src/admin-geographic-zone-population/catchment-population-auto-calc.flag.run.js
+++ b/src/admin-geographic-zone-population/catchment-population-auto-calc.flag.run.js
@@ -1,0 +1,36 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    angular
+        .module('admin-geographic-zone-view')
+        .run(setCatchmentPopulationAutoCalc);
+
+    setCatchmentPopulationAutoCalc.$inject = ['featureFlagService', 'CATCHMENT_POPULATION_CALC_AUTO_FEATURE_FLAG'];
+
+    /**
+     * @ngdoc function
+     * @name admin-geographic-zone-view.run:setCatchmentPopulationAutoCalc
+     * 
+     * @description
+     * This function sets the feature flag for catchment population auto calculation.
+     */
+    function setCatchmentPopulationAutoCalc(featureFlagService, CATCHMENT_POPULATION_CALC_AUTO_FEATURE_FLAG) {
+        featureFlagService.set(CATCHMENT_POPULATION_CALC_AUTO_FEATURE_FLAG, '${CATCHMENT_POPULATION_CALC_AUTO}', true);
+    }
+})();

--- a/src/referencedata-geographic-level/geographic-level.service.js
+++ b/src/referencedata-geographic-level/geographic-level.service.js
@@ -1,0 +1,53 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    angular
+        .module('referencedata-geographic-level')
+        .service('GeographicLevelService', GeographicLevelService);
+
+    /**
+     * @ngdoc constant
+     * @name referencedata-geographic-level.constant:GEOGRAPHIC_LEVEL
+     * 
+     * @description
+     * This constant provides the geographic level number.
+     */
+    var GEOGRAPHIC_LEVEL = {
+        NATIONAL: 1,
+        PROVINCE: 2,
+        DISTRICT: 3,
+        HEALTH_AREA: 4
+    };
+
+    function GeographicLevelService() {
+        return {
+            /**
+             * @ngdoc function
+             * @name referencedata-geographic-level.service:getTheLowestLevelNumber
+             * 
+             * @description
+             * This function returns the lowest level number. Lowest in this case means the most detailed level.
+             */
+            getTheLowestLevelNumber: function() {
+                return GEOGRAPHIC_LEVEL.HEALTH_AREA;
+            }
+        };
+    }
+
+})();


### PR DESCRIPTION
[SELV3-780](https://openlmis.atlassian.net/browse/SELV3-780)

**DRAFT - DO NOT MERGE** 

**MERGE ONLY ONCE https://github.com/OpenLMIS/openlmis-referencedata-ui/pull/49 MERGED**

Changes:
- Enable `Geographic Zones` import.
- Enable `CATCHMENT_POPULATION_CALC_AUTO` by default (in SELV).
- Add Health Area geo lvl, treat it as the "lowest" one.

[SELV3-780]: https://openlmis.atlassian.net/browse/SELV3-780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ