### PR TITLE
SELV3-845: Add exchange rate view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 1.2.1 / WIP
 ===================
+New functionality:
+- [SELV3-845](https://openlmis.atlassian.net/browse/SELV3-845)
+  - Added the Exchange Rate administration screen showing the current USD-MZM rate, its history, and a modal for entering a new rate.
 
 1.2.0 / 2026-06-09
 ===================

--- a/src/admin-exchange-rate-add/admin-exchange-rate-add.module.js
+++ b/src/admin-exchange-rate-add/admin-exchange-rate-add.module.js
@@ -1,0 +1,35 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+     * @module admin-exchange-rate-add
+     *
+     * @description
+     * Provides the modal for entering a new USD-MZM exchange rate.
+     */
+    angular.module('admin-exchange-rate-add', [
+        'openlmis-modal',
+        'openlmis-templates',
+        'openlmis-modal-state',
+        'openlmis-state-tracker',
+        'openlmis-rights',
+        'admin-exchange-rate'
+    ]);
+
+})();

--- a/src/admin-exchange-rate-add/admin-exchange-rate-add.routes.js
+++ b/src/admin-exchange-rate-add/admin-exchange-rate-add.routes.js
@@ -1,0 +1,35 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    angular.module('admin-exchange-rate-add').config(routes);
+
+    routes.$inject = ['modalStateProvider', 'ADMINISTRATION_RIGHTS'];
+
+    function routes(modalStateProvider, ADMINISTRATION_RIGHTS) {
+        modalStateProvider.state('openlmis.administration.exchangeRate.add', {
+            controller: 'ExchangeRateAddController',
+            controllerAs: 'vm',
+            templateUrl: 'admin-exchange-rate-add/exchange-rate-add.html',
+            url: '/add',
+            accessRights: [ADMINISTRATION_RIGHTS.EXCHANGE_RATE_MANAGE],
+            resolve: {},
+            parentResolves: []
+        });
+    }
+})();

--- a/src/admin-exchange-rate-add/exchange-rate-add.controller.js
+++ b/src/admin-exchange-rate-add/exchange-rate-add.controller.js
@@ -1,0 +1,103 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+     * @ngdoc controller
+     * @name admin-exchange-rate-add.controller:ExchangeRateAddController
+     *
+     * @description
+     * Handles entering a new exchange rate from the modal and reloads the list on success.
+     */
+    angular
+        .module('admin-exchange-rate-add')
+        .controller('ExchangeRateAddController', ExchangeRateAddController);
+
+    ExchangeRateAddController.$inject = [
+        '$state',
+        'loadingModalService',
+        'notificationService',
+        'stateTrackerService',
+        'ExchangeRateResource'
+    ];
+
+    function ExchangeRateAddController(
+        $state,
+        loadingModalService,
+        notificationService,
+        stateTrackerService,
+        ExchangeRateResource
+    ) {
+        var vm = this;
+
+        vm.$onInit = onInit;
+        vm.addRate = addRate;
+        vm.goToPreviousState = stateTrackerService.goToPreviousState;
+
+        /**
+         * @ngdoc property
+         * @propertyOf admin-exchange-rate-add.controller:ExchangeRateAddController
+         * @name rate
+         * @type {Number}
+         *
+         * @description
+         * The rate value entered by the user.
+         */
+        vm.rate = undefined;
+
+        /**
+         * @ngdoc method
+         * @methodOf admin-exchange-rate-add.controller:ExchangeRateAddController
+         * @name $onInit
+         *
+         * @description
+         * Initializes the controller.
+         */
+        function onInit() {
+            vm.rate = undefined;
+        }
+
+        /**
+         * @ngdoc method
+         * @methodOf admin-exchange-rate-add.controller:ExchangeRateAddController
+         * @name addRate
+         *
+         * @description
+         * Creates the entered rate. The new rate becomes the current one; on success the exchange
+         * rate list is reloaded so the header card and history refresh.
+         */
+        function addRate() {
+            loadingModalService.open();
+
+            new ExchangeRateResource().create({
+                rate: vm.rate
+            })
+                .then(function() {
+                    notificationService.success('adminExchangeRateAdd.create.success');
+                    loadingModalService.close();
+                    $state.go('openlmis.administration.exchangeRate', {}, {
+                        reload: true
+                    });
+                })
+                .catch(function() {
+                    loadingModalService.close();
+                    notificationService.error('adminExchangeRateAdd.create.failure');
+                });
+        }
+    }
+})();

--- a/src/admin-exchange-rate-add/exchange-rate-add.controller.js
+++ b/src/admin-exchange-rate-add/exchange-rate-add.controller.js
@@ -94,9 +94,11 @@
                         reload: true
                     });
                 })
-                .catch(function() {
+                .catch(function(error) {
                     loadingModalService.close();
-                    notificationService.error('adminExchangeRateAdd.create.failure');
+                    notificationService.error(
+                        error.data.message || 'adminExchangeRateAdd.create.failure'
+                    );
                 });
         }
     }

--- a/src/admin-exchange-rate-add/exchange-rate-add.controller.spec.js
+++ b/src/admin-exchange-rate-add/exchange-rate-add.controller.spec.js
@@ -1,0 +1,79 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+describe('ExchangeRateAddController', function() {
+
+    beforeEach(function() {
+        var test = this;
+        module('admin-exchange-rate-add', function($provide) {
+            test.createSpy = jasmine.createSpy('create');
+
+            $provide.factory('ExchangeRateResource', function() {
+                return function() {
+                    this.create = test.createSpy;
+                };
+            });
+        });
+
+        inject(function($injector) {
+            this.$controller = $injector.get('$controller');
+            this.$q = $injector.get('$q');
+            this.$rootScope = $injector.get('$rootScope');
+            this.$state = $injector.get('$state');
+            this.loadingModalService = $injector.get('loadingModalService');
+            this.notificationService = $injector.get('notificationService');
+        });
+
+        spyOn(this.loadingModalService, 'open').andReturn(this.$q.when());
+        spyOn(this.loadingModalService, 'close').andReturn();
+        spyOn(this.notificationService, 'success').andReturn();
+        spyOn(this.notificationService, 'error').andReturn();
+        spyOn(this.$state, 'go').andReturn();
+
+        this.vm = this.$controller('ExchangeRateAddController', {});
+        this.vm.$onInit();
+        this.vm.rate = 64.25;
+    });
+
+    it('should create the rate and reload the list on success', function() {
+        this.createSpy.andReturn(this.$q.when());
+
+        this.vm.addRate();
+        this.$rootScope.$apply();
+
+        expect(this.createSpy).toHaveBeenCalledWith({
+            rate: 64.25
+        });
+
+        expect(this.notificationService.success)
+            .toHaveBeenCalledWith('adminExchangeRateAdd.create.success');
+
+        expect(this.$state.go).toHaveBeenCalledWith('openlmis.administration.exchangeRate', {}, {
+            reload: true
+        });
+    });
+
+    it('should notify the user when creating the rate fails', function() {
+        this.createSpy.andReturn(this.$q.reject());
+
+        this.vm.addRate();
+        this.$rootScope.$apply();
+
+        expect(this.notificationService.error)
+            .toHaveBeenCalledWith('adminExchangeRateAdd.create.failure');
+
+        expect(this.$state.go).not.toHaveBeenCalled();
+    });
+});

--- a/src/admin-exchange-rate-add/exchange-rate-add.html
+++ b/src/admin-exchange-rate-add/exchange-rate-add.html
@@ -1,0 +1,28 @@
+<div class="modal" role="dialog" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1>{{:: 'adminExchangeRateAdd.newRate' | message}}</h1>
+            </div>
+            <div class="modal-body">
+                <form id="exchange-rate-add-form" ng-submit="vm.addRate()">
+                    <label for="rate" class="is-required">{{:: 'adminExchangeRateAdd.rate' | message}}</label>
+                    <input id="rate"
+                           type="number"
+                           step="any"
+                           min="0"
+                           ng-model="vm.rate"
+                           required/>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button ng-click="vm.goToPreviousState('openlmis.administration.exchangeRate')">
+                    {{:: 'adminExchangeRateAdd.cancel' | message}}
+                </button>
+                <button class="primary" form="exchange-rate-add-form">
+                    {{:: 'adminExchangeRateAdd.create' | message}}
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/admin-exchange-rate-add/messages_en.json
+++ b/src/admin-exchange-rate-add/messages_en.json
@@ -1,0 +1,8 @@
+{
+    "adminExchangeRateAdd.newRate": "Add new exchange rate",
+    "adminExchangeRateAdd.rate": "Rate",
+    "adminExchangeRateAdd.create": "Submit",
+    "adminExchangeRateAdd.cancel": "Cancel",
+    "adminExchangeRateAdd.create.success": "The exchange rate has been saved.",
+    "adminExchangeRateAdd.create.failure": "Failed to save the exchange rate."
+}

--- a/src/admin-exchange-rate-list/_admin-exchange-rate-list.scss
+++ b/src/admin-exchange-rate-list/_admin-exchange-rate-list.scss
@@ -1,0 +1,36 @@
+.exchange-rate-list {
+
+    // Align the add button with the table's right edge.
+    button.add {
+        margin-right: 0;
+    }
+
+    // Keep a gap before the pagination controls.
+    .openlmis-pagination .pagination-info {
+        margin-right: $space-size;
+    }
+
+    .exchange-rate-current {
+
+        // Align the current-rate block with the table's left edge.
+        margin-left: 0;
+
+        dd {
+            margin-left: 0;
+        }
+
+        .exchange-rate-current-value {
+            display: block;
+            font-size: 1.6em;
+            font-weight: bold;
+            line-height: 1.3;
+        }
+
+        .exchange-rate-current-meta {
+            display: block;
+            color: #666;
+        }
+
+    }
+
+}

--- a/src/admin-exchange-rate-list/_admin-exchange-rate-list.scss
+++ b/src/admin-exchange-rate-list/_admin-exchange-rate-list.scss
@@ -33,4 +33,20 @@
 
     }
 
+    // On phones the info and page links don't fit on one row (links get cut off),
+    // so stack them vertically and centre both.
+    @media screen and (max-width: $res-sm) {
+
+        .openlmis-pagination {
+            flex-direction: column;
+            align-items: center;
+
+            .pagination-info {
+                margin-right: 0;
+                margin-bottom: $space-size;
+            }
+        }
+
+    }
+
 }

--- a/src/admin-exchange-rate-list/_admin-exchange-rate-list.scss
+++ b/src/admin-exchange-rate-list/_admin-exchange-rate-list.scss
@@ -28,7 +28,7 @@
 
         .exchange-rate-current-meta {
             display: block;
-            color: #666;
+            color: $gray;
         }
 
     }

--- a/src/admin-exchange-rate-list/admin-exchange-rate-list.module.js
+++ b/src/admin-exchange-rate-list/admin-exchange-rate-list.module.js
@@ -1,0 +1,35 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+     * @module admin-exchange-rate-list
+     *
+     * @description
+     * Provides the administration screen listing the current USD-MZM exchange rate and its history.
+     */
+    angular.module('admin-exchange-rate-list', [
+        'openlmis-admin',
+        'openlmis-pagination',
+        'openlmis-rights',
+        'openlmis-templates',
+        'admin-exchange-rate',
+        'ui.router'
+    ]);
+
+})();

--- a/src/admin-exchange-rate-list/admin-exchange-rate-list.routes.js
+++ b/src/admin-exchange-rate-list/admin-exchange-rate-list.routes.js
@@ -1,0 +1,49 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    angular.module('admin-exchange-rate-list').config(routes);
+
+    routes.$inject = ['$stateProvider', 'ADMINISTRATION_RIGHTS'];
+
+    function routes($stateProvider, ADMINISTRATION_RIGHTS) {
+
+        $stateProvider.state('openlmis.administration.exchangeRate', {
+            showInNavigation: true,
+            label: 'adminExchangeRateList.exchangeRate',
+            url: '/exchangeRate?page&size',
+            controller: 'ExchangeRateListController',
+            templateUrl: 'admin-exchange-rate-list/exchange-rate-list.html',
+            controllerAs: 'vm',
+            accessRights: [ADMINISTRATION_RIGHTS.EXCHANGE_RATE_MANAGE],
+            resolve: {
+                currentRate: function(ExchangeRateResource) {
+                    return new ExchangeRateResource().get('current')
+                        .catch(function() {
+                            return undefined;
+                        });
+                },
+                rates: function(paginationService, ExchangeRateResource, $stateParams) {
+                    return paginationService.registerList(null, $stateParams, function() {
+                        return new ExchangeRateResource().query();
+                    });
+                }
+            }
+        });
+    }
+})();

--- a/src/admin-exchange-rate-list/admin-exchange-rate-list.routes.js
+++ b/src/admin-exchange-rate-list/admin-exchange-rate-list.routes.js
@@ -32,9 +32,10 @@
             controllerAs: 'vm',
             accessRights: [ADMINISTRATION_RIGHTS.EXCHANGE_RATE_MANAGE],
             resolve: {
-                currentRate: function(ExchangeRateResource) {
+                currentRate: function(ExchangeRateResource, notificationService) {
                     return new ExchangeRateResource().get('current')
-                        .catch(function() {
+                        .catch(function(error) {
+                            notificationService.error(error.data.message);
                             return undefined;
                         });
                 },

--- a/src/admin-exchange-rate-list/admin-exchange-rate-list.routes.spec.js
+++ b/src/admin-exchange-rate-list/admin-exchange-rate-list.routes.spec.js
@@ -1,0 +1,102 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+describe('openlmis.administration.exchangeRate state', function() {
+
+    'use strict';
+
+    beforeEach(function() {
+        var test = this;
+        module('admin-exchange-rate-list', function($provide) {
+            test.getSpy = jasmine.createSpy('get');
+            test.querySpy = jasmine.createSpy('query');
+
+            $provide.factory('ExchangeRateResource', function() {
+                return function() {
+                    this.get = test.getSpy;
+                    this.query = test.querySpy;
+                };
+            });
+        });
+
+        inject(function($injector) {
+            this.$state = $injector.get('$state');
+            this.$location = $injector.get('$location');
+            this.$rootScope = $injector.get('$rootScope');
+            this.$q = $injector.get('$q');
+            this.$templateCache = $injector.get('$templateCache');
+        });
+
+        this.currentRate = {
+            rate: 64.25,
+            validFrom: '2026-06-23T08:29:20Z',
+            createdByName: 'Admin Admin'
+        };
+
+        this.getSpy.andReturn(this.$q.when(this.currentRate));
+        this.querySpy.andReturn(this.$q.when([this.currentRate]));
+
+        this.$state.go('openlmis');
+        this.$rootScope.$apply();
+
+        this.goToUrl = function(url) {
+            this.$location.url(url);
+            this.$rootScope.$apply();
+        };
+
+        this.getResolvedValue = function(name) {
+            return this.$state.$current.locals.globals[name];
+        };
+    });
+
+    it('should be available under /administration/exchangeRate URL', function() {
+        expect(this.$state.current.name).not.toEqual('openlmis.administration.exchangeRate');
+
+        this.goToUrl('/administration/exchangeRate');
+
+        expect(this.$state.current.name).toEqual('openlmis.administration.exchangeRate');
+    });
+
+    it('should use html template', function() {
+        spyOn(this.$templateCache, 'get').andCallThrough();
+
+        this.goToUrl('/administration/exchangeRate');
+
+        expect(this.$templateCache.get)
+            .toHaveBeenCalledWith('admin-exchange-rate-list/exchange-rate-list.html');
+    });
+
+    it('should resolve the current rate', function() {
+        this.goToUrl('/administration/exchangeRate');
+
+        expect(this.getResolvedValue('currentRate')).toEqual(this.currentRate);
+        expect(this.getSpy).toHaveBeenCalledWith('current');
+    });
+
+    it('should resolve undefined current rate when the request fails', function() {
+        this.getSpy.andReturn(this.$q.reject());
+
+        this.goToUrl('/administration/exchangeRate');
+
+        expect(this.getResolvedValue('currentRate')).toBeUndefined();
+    });
+
+    it('should resolve the rate history', function() {
+        this.goToUrl('/administration/exchangeRate');
+
+        expect(this.getResolvedValue('rates').length).toEqual(1);
+        expect(this.querySpy).toHaveBeenCalled();
+    });
+});

--- a/src/admin-exchange-rate-list/exchange-rate-list.controller.js
+++ b/src/admin-exchange-rate-list/exchange-rate-list.controller.js
@@ -1,0 +1,85 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+     * @ngdoc controller
+     * @name admin-exchange-rate-list.controller:ExchangeRateListController
+     *
+     * @description
+     * Exposes the current exchange rate and the full history to the exchange rate screen.
+     */
+    angular
+        .module('admin-exchange-rate-list')
+        .controller('ExchangeRateListController', controller);
+
+    controller.$inject = ['currentRate', 'rates'];
+
+    function controller(currentRate, rates) {
+
+        var vm = this;
+        vm.$onInit = onInit;
+
+        /**
+         * @ngdoc property
+         * @propertyOf admin-exchange-rate-list.controller:ExchangeRateListController
+         * @name currentRate
+         * @type {Object}
+         *
+         * @description
+         * The currently active exchange rate, or undefined when none has been entered.
+         */
+        vm.currentRate = undefined;
+
+        /**
+         * @ngdoc property
+         * @propertyOf admin-exchange-rate-list.controller:ExchangeRateListController
+         * @name rates
+         * @type {Array}
+         *
+         * @description
+         * The exchange rate history, newest first.
+         */
+        vm.rates = [];
+
+        /**
+         * @ngdoc property
+         * @propertyOf admin-exchange-rate-list.controller:ExchangeRateListController
+         * @name pagedRates
+         * @type {Array}
+         *
+         * @description
+         * The current page of the exchange rate history, filled by the pagination component.
+         */
+        vm.pagedRates = [];
+
+        /**
+         * @ngdoc method
+         * @methodOf admin-exchange-rate-list.controller:ExchangeRateListController
+         * @name $onInit
+         *
+         * @description
+         * Initializes the controller with the resolved current rate and history.
+         */
+        function onInit() {
+            vm.currentRate = currentRate;
+            vm.rates = rates;
+        }
+    }
+
+})();

--- a/src/admin-exchange-rate-list/exchange-rate-list.controller.spec.js
+++ b/src/admin-exchange-rate-list/exchange-rate-list.controller.spec.js
@@ -1,0 +1,46 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+describe('ExchangeRateListController', function() {
+
+    beforeEach(function() {
+        module('admin-exchange-rate-list');
+
+        inject(function($injector) {
+            this.$controller = $injector.get('$controller');
+        });
+
+        this.currentRate = {
+            rate: 64.25,
+            validFrom: '2026-06-23T08:29:20Z',
+            createdByName: 'Admin Admin'
+        };
+        this.rates = [this.currentRate];
+
+        this.vm = this.$controller('ExchangeRateListController', {
+            currentRate: this.currentRate,
+            rates: this.rates
+        });
+        this.vm.$onInit();
+    });
+
+    it('should expose the resolved current rate', function() {
+        expect(this.vm.currentRate).toEqual(this.currentRate);
+    });
+
+    it('should expose the resolved rate history', function() {
+        expect(this.vm.rates).toEqual(this.rates);
+    });
+});

--- a/src/admin-exchange-rate-list/exchange-rate-list.html
+++ b/src/admin-exchange-rate-list/exchange-rate-list.html
@@ -1,0 +1,35 @@
+<h2>{{:: 'adminExchangeRateList.exchangeRate' | message}}</h2>
+<section class="openlmis-table-container exchange-rate-list">
+    <button class="add" ui-sref="openlmis.administration.exchangeRate.add">
+        {{:: 'adminExchangeRateList.newRate' | message}}
+    </button>
+    <dl class="exchange-rate-current">
+        <dt>{{:: 'adminExchangeRateList.currentRate' | message}}</dt>
+        <dd ng-if="vm.currentRate.rate">
+            <span class="exchange-rate-current-value">{{vm.currentRate.rate | number}} {{:: 'adminExchangeRateList.currencyPair' | message}}</span>
+            <span class="exchange-rate-current-meta">{{:: 'adminExchangeRateList.enteredOn' | message}} {{vm.currentRate.validFrom | openlmisDatetime}}</span>
+            <span class="exchange-rate-current-meta">{{:: 'adminExchangeRateList.enteredBy' | message}} {{vm.currentRate.createdByName}}</span>
+        </dd>
+        <dd ng-if="!vm.currentRate.rate">{{:: 'adminExchangeRateList.noRate' | message}}</dd>
+    </dl>
+    <table>
+        <caption ng-if="vm.rates.length === 0">
+            {{:: 'adminExchangeRateList.noRates' | message}}
+        </caption>
+        <thead>
+        <tr>
+            <th>{{:: 'adminExchangeRateList.rate' | message}}</th>
+            <th>{{:: 'adminExchangeRateList.validFrom' | message}}</th>
+            <th>{{:: 'adminExchangeRateList.enteredBy' | message}}</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr ng-repeat="rate in vm.pagedRates">
+            <td>{{rate.rate | number}} {{:: 'adminExchangeRateList.currencyPair' | message}}</td>
+            <td>{{rate.validFrom | openlmisDatetime}}</td>
+            <td>{{rate.createdByName}}</td>
+        </tr>
+        </tbody>
+    </table>
+    <openlmis-pagination list="vm.rates" paged-list="vm.pagedRates"/>
+</section>

--- a/src/admin-exchange-rate-list/messages_en.json
+++ b/src/admin-exchange-rate-list/messages_en.json
@@ -1,0 +1,12 @@
+{
+    "adminExchangeRateList.exchangeRate": "Exchange Rate",
+    "adminExchangeRateList.currentRate": "Current rate",
+    "adminExchangeRateList.newRate": "New rate",
+    "adminExchangeRateList.rate": "Rate",
+    "adminExchangeRateList.currencyPair": "MZM / USD",
+    "adminExchangeRateList.validFrom": "Valid from",
+    "adminExchangeRateList.enteredBy": "Entered by",
+    "adminExchangeRateList.enteredOn": "Entered on",
+    "adminExchangeRateList.noRate": "No exchange rate has been set yet.",
+    "adminExchangeRateList.noRates": "No exchange rates have been entered yet."
+}

--- a/src/admin-exchange-rate/admin-exchange-rate.module.js
+++ b/src/admin-exchange-rate/admin-exchange-rate.module.js
@@ -1,0 +1,31 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+     * @module admin-exchange-rate
+     *
+     * @description
+     * Provides the exchange rate resource shared by the administration exchange rate screens.
+     */
+    angular.module('admin-exchange-rate', [
+        'openlmis-repository',
+        'openlmis-class-extender'
+    ]);
+
+})();

--- a/src/admin-exchange-rate/exchange-rate.resource.js
+++ b/src/admin-exchange-rate/exchange-rate.resource.js
@@ -1,0 +1,60 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+     * @ngdoc service
+     * @name admin-exchange-rate.ExchangeRateResource
+     *
+     * @description
+     * Communicates with the USD-MZM exchange rate REST endpoints exposed by the fulfillment
+     * extension. Reads are open to any authenticated user; creating a rate requires the
+     * EXCHANGE_RATE_MANAGE right (enforced server-side).
+     */
+    angular
+        .module('admin-exchange-rate')
+        .factory('ExchangeRateResource', ExchangeRateResource);
+
+    ExchangeRateResource.$inject = ['OpenlmisResource', 'classExtender'];
+
+    function ExchangeRateResource(OpenlmisResource, classExtender) {
+
+        classExtender.extend(ExchangeRateResource, OpenlmisResource);
+
+        return ExchangeRateResource;
+
+        /**
+         * @ngdoc method
+         * @methodOf admin-exchange-rate.ExchangeRateResource
+         * @name ExchangeRateResource
+         * @constructor
+         *
+         * @description
+         * Creates an instance of the ExchangeRateResource class pointing at the exchange rate
+         * endpoint. The history endpoint returns a plain array (not a page), hence paginated:false;
+         * the current rate is fetched with get('current').
+         */
+        function ExchangeRateResource() {
+            this.super('/api/exchangeRates', {
+                paginated: false
+            });
+        }
+
+    }
+
+})();

--- a/src/admin-exchange-rate/exchange-rate.resource.spec.js
+++ b/src/admin-exchange-rate/exchange-rate.resource.spec.js
@@ -1,0 +1,40 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+describe('ExchangeRateResource', function() {
+
+    beforeEach(function() {
+        var test = this;
+        module('admin-exchange-rate', function($provide) {
+            test.OpenlmisResourceMock = jasmine.createSpy('OpenlmisResource');
+
+            $provide.factory('OpenlmisResource', function() {
+                return test.OpenlmisResourceMock;
+            });
+        });
+
+        inject(function($injector) {
+            this.ExchangeRateResource = $injector.get('ExchangeRateResource');
+        });
+    });
+
+    it('should extend OpenlmisResource pointing at the exchange rate endpoint, non-paginated', function() {
+        new this.ExchangeRateResource();
+
+        expect(this.OpenlmisResourceMock).toHaveBeenCalledWith('/api/exchangeRates', {
+            paginated: false
+        });
+    });
+});

--- a/src/openlmis-rights/administration-rights.constant.js
+++ b/src/openlmis-rights/administration-rights.constant.js
@@ -53,8 +53,11 @@
             REPORT_CATEGORIES_MANAGE: 'REPORT_CATEGORIES_MANAGE',
             REPORTS_MANAGE: 'REPORTS_MANAGE',
             // SELV3-670: Secure DHIS2 page 
-            MANAGE_DHIS2: 'MANAGE_DHIS2'
+            MANAGE_DHIS2: 'MANAGE_DHIS2',
             // SELV3-670: Ends here
+            // SELV3-845: Exchange rate management
+            EXCHANGE_RATE_MANAGE: 'EXCHANGE_RATE_MANAGE'
+            // SELV3-845: Ends here
         };
     }
 


### PR DESCRIPTION
Adds an Exchange Rate screen under Administration. Shows the current USD→MZM rate with who/when entered it, full history newest-first, and a "New rate" modal that inserts a rate which becomes current immediately. Consumes the SELV3-844 fulfillment-extension endpoints; gated by the EXCHANGE_RATE_MANAGE right.